### PR TITLE
Skip loading permissions during `assets:precompile`

### DIFF
--- a/lib/solidus_user_roles/engine.rb
+++ b/lib/solidus_user_roles/engine.rb
@@ -18,6 +18,9 @@ module SolidusUserRoles
     end
 
     def self.load_custom_permissions
+      # We do not need to load custom permissions when running the `asset:precompile` Rake task.
+      return if asset_precompilation_step?
+
       # Ensure connection to DB is available and both tables exist before assigning permissions
       if database_connection_available? &&
           (ActiveRecord::Base.connection.tables & ['spree_roles', 'spree_permission_sets']).to_a.length == 2
@@ -43,6 +46,10 @@ module SolidusUserRoles
     config.to_prepare(&method(:activate).to_proc)
 
     private
+
+    def self.asset_precompilation_step?
+      ARGV.include? "assets:precompile"
+    end
 
     def self.database_connection_available?
       ActiveRecord::Base.connection rescue false


### PR DESCRIPTION
Hi there,

Hope you all are well.

Because of how Rails engines are mounted when Rake tasks are being run, the `Engine.load_custom_permissions` here is hit before the Rails server boots--during any other deploy step.

This can make the `assets:precompile` Rake task complete *much faster* in the case that the database cannot be connnected to and the `ActiveRecord::Connection` times out after 60 seconds, for example.

---

More info about why I'm making this change, for the curious:

This makes any Rake task run as part of the application build process dependent on the database when it doesn't need to be. This can cause issues if the database is unavailable during the build step.

For example: the Heroku Ruby buildpack runs `assets:precompile` during its build process. But Heroku build dynos do not have static or stable IP addresses, meaning that the database may reject a connection or the connection may time out.

Although `Engine.load_custom_permissions` already rescues from database connection errors, this can be slow in the case that the connection error is a time out.